### PR TITLE
Add retry in case of server error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-appstore',
-      version='0.3.0',
+      version='0.3.1',
       description='Singer.io tap for extracting data from the App Store Connect API',
       author='JustEdro',
       url='https://github.com/JustEdro',
@@ -13,7 +13,8 @@ setup(name='tap-appstore',
           'singer-python==5.13.0',
           'appstoreconnect==0.10.0',
           'pytz==2023.3',
-          'python-dateutil>=2.8.2,<3.0.0'
+          'python-dateutil>=2.8.2,<3.0.0',
+          'tenacity==8.2.3'
       ],
       extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-appstore',
-      version='0.3.1',
+      version='0.3.3',
       description='Singer.io tap for extracting data from the App Store Connect API',
       author='JustEdro',
       url='https://github.com/JustEdro',

--- a/tap_appstore/discover.py
+++ b/tap_appstore/discover.py
@@ -1,7 +1,9 @@
+import requests
 import singer
 from appstoreconnect import Api
 from appstoreconnect.api import APIError
 from singer.catalog import Catalog, CatalogEntry
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from tap_appstore.schema import load_schemas
 from tap_appstore.streams import STREAMS
@@ -16,6 +18,10 @@ def do_discover(client: Api) -> Catalog:
     return catalog
 
 
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_fixed(1),
+)
 def discover(client: Api) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return catalog.

--- a/tap_appstore/discover.py
+++ b/tap_appstore/discover.py
@@ -22,8 +22,6 @@ def do_discover(client: Api) -> Catalog:
     stop=stop_after_attempt(5),
     wait=wait_fixed(1),
     retry=retry_if_exception_type(APIError),
-    after=lambda retry_state: LOGGER.info(f"Retrying... Attempt {retry_state.attempt_number} "
-                                          f"failed with error: {retry_state.outcome.exception()}"),
     reraise=True
 )
 def discover(client: Api) -> Catalog:
@@ -35,11 +33,8 @@ def discover(client: Api) -> Catalog:
     for schema_name, schema in schemas.items():
         LOGGER.info("Discovering schema for %s", schema_name)
 
-        try:
-            # checking API credentials
-            assert len(client.list_users()) > 0, 'API call failed - List of users is empty'
-        except APIError as e:
-            raise Exception(f'API Call failed {e}')
+        # checking API credentials
+        assert len(client.list_users()) > 0, 'API call failed - List of users is empty'
 
         if schema_name in STREAMS:
             # create and add catalog entry

--- a/tap_appstore/discover.py
+++ b/tap_appstore/discover.py
@@ -3,7 +3,7 @@ import singer
 from appstoreconnect import Api
 from appstoreconnect.api import APIError
 from singer.catalog import Catalog, CatalogEntry
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_exception_type
 
 from tap_appstore.schema import load_schemas
 from tap_appstore.streams import STREAMS
@@ -21,6 +21,8 @@ def do_discover(client: Api) -> Catalog:
 @retry(
     stop=stop_after_attempt(5),
     wait=wait_fixed(1),
+    retry=retry_if_exception_type(APIError),
+    reraise=True
 )
 def discover(client: Api) -> Catalog:
     """

--- a/tap_appstore/discover.py
+++ b/tap_appstore/discover.py
@@ -22,6 +22,8 @@ def do_discover(client: Api) -> Catalog:
     stop=stop_after_attempt(5),
     wait=wait_fixed(1),
     retry=retry_if_exception_type(APIError),
+    after=lambda retry_state: LOGGER.info(f"Retrying... Attempt {retry_state.attempt_number} "
+                                          f"failed with error: {retry_state.outcome.exception()}"),
     reraise=True
 )
 def discover(client: Api) -> Catalog:

--- a/tap_appstore/sync.py
+++ b/tap_appstore/sync.py
@@ -3,10 +3,12 @@ from typing import List
 import singer
 from appstoreconnect import Api
 from singer import CatalogEntry, Catalog
+from tenacity import stop_after_attempt, wait_fixed, retry
 
 from tap_appstore.streams import STREAMS
 
 LOGGER = singer.get_logger()
+
 
 def get_selected_streams(catalog: Catalog) -> List[CatalogEntry]:
     selected_streams = []
@@ -18,6 +20,10 @@ def get_selected_streams(catalog: Catalog) -> List[CatalogEntry]:
     return selected_streams
 
 
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_fixed(1),
+)
 def sync(client: Api, config, state, catalog: Catalog):
     for catalog_entry in get_selected_streams(catalog):
         LOGGER.info("Syncing stream %s", catalog_entry.tap_stream_id)

--- a/tap_appstore/sync.py
+++ b/tap_appstore/sync.py
@@ -25,6 +25,8 @@ def get_selected_streams(catalog: Catalog) -> List[CatalogEntry]:
     stop=stop_after_attempt(5),
     wait=wait_fixed(1),
     retry=retry_if_exception_type(APIError),
+    after=lambda retry_state: LOGGER.info(f"Retrying... Attempt {retry_state.attempt_number} "
+                                          f"failed with error: {retry_state.outcome.exception()}"),
     reraise=True
 )
 def sync(client: Api, config, state, catalog: Catalog):

--- a/tap_appstore/sync.py
+++ b/tap_appstore/sync.py
@@ -2,8 +2,9 @@ from typing import List
 
 import singer
 from appstoreconnect import Api
+from appstoreconnect.api import APIError
 from singer import CatalogEntry, Catalog
-from tenacity import stop_after_attempt, wait_fixed, retry
+from tenacity import stop_after_attempt, wait_fixed, retry, retry_if_exception_type
 
 from tap_appstore.streams import STREAMS
 
@@ -23,6 +24,8 @@ def get_selected_streams(catalog: Catalog) -> List[CatalogEntry]:
 @retry(
     stop=stop_after_attempt(5),
     wait=wait_fixed(1),
+    retry=retry_if_exception_type(APIError),
+    reraise=True
 )
 def sync(client: Api, config, state, catalog: Catalog):
     for catalog_entry in get_selected_streams(catalog):

--- a/tap_appstore/sync.py
+++ b/tap_appstore/sync.py
@@ -25,8 +25,6 @@ def get_selected_streams(catalog: Catalog) -> List[CatalogEntry]:
     stop=stop_after_attempt(5),
     wait=wait_fixed(1),
     retry=retry_if_exception_type(APIError),
-    after=lambda retry_state: LOGGER.info(f"Retrying... Attempt {retry_state.attempt_number} "
-                                          f"failed with error: {retry_state.outcome.exception()}"),
     reraise=True
 )
 def sync(client: Api, config, state, catalog: Catalog):

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from appstoreconnect.api import APIError
+
+from tap_appstore import discover
+
+
+class TestDiscover(unittest.TestCase):
+
+    @patch('appstoreconnect.Api.list_users')
+    @patch('time.sleep')
+    def test_discover_retries_on_api_error(self, mock_sleep, mock_list_users):
+        def raise_api_exception(*args, **kwargs):
+            raise APIError('APIError')
+        # Set up a side effect for the mock to raise APIError for the first 3 calls, then return an empty list
+        mock_list_users.side_effect = [APIError('APIError') for _ in range(3)] + [[]]
+
+        client = Mock()
+        client.list_users = mock_list_users
+
+        with self.assertRaises(AssertionError) as e:
+            discover(client)
+
+        # Ensure list_users was called 4 times (3 retries because of APIError + 1 assertion error)
+        assert mock_list_users.call_count == 4
+        assert str(e.exception) == 'API call failed - List of users is empty'
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -11,8 +11,6 @@ class TestDiscover(unittest.TestCase):
     @patch('appstoreconnect.Api.list_users')
     @patch('time.sleep')
     def test_discover_retries_on_api_error(self, mock_sleep, mock_list_users):
-        def raise_api_exception(*args, **kwargs):
-            raise APIError('APIError')
         # Set up a side effect for the mock to raise APIError for the first 3 calls, then return an empty list
         mock_list_users.side_effect = [APIError('APIError') for _ in range(3)] + [[]]
 


### PR DESCRIPTION
The applestore API server is facing some instability, so this PR adds more retries to avoid sync failure because single request.

```
Exception: API Call failed An unexpected error occurred on the server side. If this issue continues, contact us at https://developer.apple.com/contact/.
```

Manually tested.