### PR TITLE
feat: support `key_file_str` config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ Sample config:
   "start_date": "2019-02-01T00:00:00Z"
 }
 ```
+
+Optionally `key_file_str` can be used instead of `key_file`.
+If `key_file_str` is provided it will be written to a temporary file and used as the key file, then later deleted on exit.
+The input of that key must have new line characters `\n` for the line breaks in the key file contents.
+
+An example could look like:
+
+```$json
+{
+  "key_id": "AAAAAAAAA",
+  "key_file_str": ".-----BEGIN PRIVATE KEY-----\nfoo\nbar\nbaz\nother\n-----END PRIVATE KEY-----",
+  "issuer_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "vendor": "3333333",
+  "start_date": "2019-02-01T00:00:00Z"
+}
+```

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-appstore',
       py_modules=['tap-appstore'],
       install_requires=[
           'singer-python==5.13.0',
-          'appstoreconnect==0.10.0',
+          'appstoreconnect==0.10.1',
           'pytz==2023.3',
           'python-dateutil>=2.8.2,<3.0.0',
           'tenacity==8.2.3'

--- a/tap_appstore/__init__.py
+++ b/tap_appstore/__init__.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
+import atexit
 import json
+import os
+import tempfile
 
 import singer
 from appstoreconnect import Api
-from singer import utils, Catalog
+from singer import Catalog, utils
 
 from tap_appstore.discover import discover, do_discover
 from tap_appstore.sync import sync
 
 REQUIRED_CONFIG_KEYS = [
     'key_id',
-    'key_file',
     'issuer_id',
     'vendor',
     'start_date'
@@ -18,6 +20,21 @@ REQUIRED_CONFIG_KEYS = [
 
 LOGGER = singer.get_logger()
 
+def _delete_temp_file(temp_filename) -> None:
+    try:
+        LOGGER.info(f"Cleaning up: {temp_filename}")
+    finally:
+        os.remove(temp_filename)
+        LOGGER.info(f"Temporary key_file deleted: {temp_filename}")
+
+def _create_temp_key_file(key_file_str) -> str:
+    temp_file = tempfile.NamedTemporaryFile(delete=False)
+    temp_filename = temp_file.name
+    with open(temp_filename, "w") as file:
+        file.write(key_file_str)
+    LOGGER.info(f"Temporary key_file created: {temp_filename}")
+    atexit.register(_delete_temp_file, temp_filename)
+    return temp_filename
 
 @utils.handle_top_exception(LOGGER)
 def main():
@@ -25,6 +42,12 @@ def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
 
     config = args.config
+    if "key_file" not in config and "key_file_str" not in config:
+        raise Exception("Config is missing required keys: key_file or key_file_str.")
+
+    if config.get('key_file_str'):
+        config['key_file'] = _create_temp_key_file(config.pop("key_file_str"))
+
     client = Api(config['key_id'], config['key_file'], config['issuer_id'], submit_stats=False)
 
     state = {}

--- a/tap_appstore/schemas/financial_report.json
+++ b/tap_appstore/schemas/financial_report.json
@@ -21,8 +21,7 @@
             "type": [
             "null",
             "string"
-            ],
-            "format" : "date"
+            ]
         },
         "vendor_identifier": {
             "type": [
@@ -40,15 +39,13 @@
             "type": [
                 "null",
                 "string"
-            ],
-            "format" : "date"
+            ]
         },
         "end_date": {
             "type": [
                 "null",
                 "string"
-            ],
-            "format" : "date"
+            ]
         },
         "quantity": {
             "type": [

--- a/tap_appstore/schemas/sales_report.json
+++ b/tap_appstore/schemas/sales_report.json
@@ -88,15 +88,13 @@
             "type": [
                 "null",
                 "string"
-            ],
-            "format" : "date"
+            ]
         },
         "end_date": {
             "type": [
                 "null",
                 "string"
-            ],
-            "format" : "date"
+            ]
         },
         "customer_currency": {
             "type": [

--- a/tap_appstore/schemas/subscriber_report.json
+++ b/tap_appstore/schemas/subscriber_report.json
@@ -34,8 +34,7 @@
             "type" : [
                 "null",
                 "string"
-            ],
-            "format": "date"
+            ]
         },
         "app_name" : {
             "type" : [

--- a/tap_appstore/schemas/subscriber_report.json
+++ b/tap_appstore/schemas/subscriber_report.json
@@ -179,8 +179,7 @@
             "type" : [
                 "null",
                 "string"
-            ],
-            "format": "date"
+            ]
         },
         "units" : {
             "type" : [


### PR DESCRIPTION
Depending on the runtime environment it might be more work to have the key_file pre-installed on the machine before running the tap. This PR allows you to either specify a key_file path or a key_file_str that contains the string contents that would normally be in the key_file.

- Dont required the key_file config anymore
- Add a special check for either key_file or key_file_str
- When key_file_str is present, write it to a temp file and set that path as the new key_file value. Clean up the file at exit.
- README update to include the changes

Additional Chores:
- we noticed some schema type bugs related to dates https://github.com/MeltanoLabs/tap-appstore/issues/2 that we fixed here
- The appstoreconnect had a new patch version that helps resolve some `crytography` dependency install issues we saw in some cases