### PR TITLE
Fix schemas with date format but empty values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ venv.bak/
 .idea
 *.iml
 secrets
+output

--- a/meltano.yml
+++ b/meltano.yml
@@ -1,0 +1,36 @@
+version: 1
+default_environment: prod
+environments:
+- name: prod
+plugins:
+  extractors:
+  - name: tap-appstore
+    namespace: tap-appstore
+    pip_url: -e .
+    capabilities:
+    - state
+    - catalog
+    - discover
+    settings:
+    - name: vendor
+      label: Vendor
+      description: Appstore vendor number.
+    - name: issuer_id
+      label: Issuer ID
+      description: Appstore issuer ID
+    - name: start_date
+      label: Start Date
+      description: Determines how much historical data will be extracted. Please be
+        aware that the larger the time period and amount of data, the longer the initial
+        extraction can be expected to take.
+    - name: key_id
+      label: Key ID
+      description: Appstore key ID.
+    - name: key_file
+      label: Key File
+      description: Appstore key file.
+  loaders:
+  - name: target-parquet
+    variant: automattic
+    pip_url: git+https://github.com/Automattic/target-parquet.git
+project_id: 181a1bcb-5ac9-442f-b1bd-08cd21752301

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-appstore',
-      version='0.3.3',
+      version='0.3.4',
       description='Singer.io tap for extracting data from the App Store Connect API',
       author='JustEdro',
       url='https://github.com/JustEdro',
@@ -11,7 +11,7 @@ setup(name='tap-appstore',
       py_modules=['tap-appstore'],
       install_requires=[
           'singer-python==5.13.0',
-          'appstoreconnect==0.10.0',
+          'appstoreconnect==0.10.1',
           'pytz==2023.3',
           'python-dateutil>=2.8.2,<3.0.0',
           'tenacity==8.2.3'

--- a/tap_appstore/schemas/financial_report.json
+++ b/tap_appstore/schemas/financial_report.json
@@ -39,15 +39,13 @@
             "type": [
                 "null",
                 "string"
-            ],
-            "format" : "date"
+            ]
         },
         "end_date": {
             "type": [
                 "null",
                 "string"
-            ],
-            "format" : "date"
+            ]
         },
         "quantity": {
             "type": [

--- a/tap_appstore/schemas/financial_report.json
+++ b/tap_appstore/schemas/financial_report.json
@@ -21,8 +21,7 @@
             "type": [
             "null",
             "string"
-            ],
-            "format" : "date"
+            ]
         },
         "vendor_identifier": {
             "type": [

--- a/tap_appstore/schemas/sales_report.json
+++ b/tap_appstore/schemas/sales_report.json
@@ -88,15 +88,13 @@
             "type": [
                 "null",
                 "string"
-            ],
-            "format" : "date"
+            ]
         },
         "end_date": {
             "type": [
                 "null",
                 "string"
-            ],
-            "format" : "date"
+            ]
         },
         "customer_currency": {
             "type": [

--- a/tap_appstore/schemas/subscriber_report.json
+++ b/tap_appstore/schemas/subscriber_report.json
@@ -180,7 +180,6 @@
                 "null",
                 "string"
             ],
-            "format": "date"
         },
         "units" : {
             "type" : [

--- a/tap_appstore/schemas/subscriber_report.json
+++ b/tap_appstore/schemas/subscriber_report.json
@@ -34,8 +34,7 @@
             "type" : [
                 "null",
                 "string"
-            ],
-            "format": "date"
+            ]
         },
         "app_name" : {
             "type" : [

--- a/tap_appstore/schemas/subscriber_report.json
+++ b/tap_appstore/schemas/subscriber_report.json
@@ -179,7 +179,7 @@
             "type" : [
                 "null",
                 "string"
-            ],
+            ]
         },
         "units" : {
             "type" : [


### PR DESCRIPTION
Singer sdk can't validate date format with an empty value (only null is accepted). So we need to remove the format to allow use this tap with a target build with singer sdk.